### PR TITLE
Revert "Olympics" merge to master 

### DIFF
--- a/src/articles/2021-07-28-tokyo-olympics.mdx
+++ b/src/articles/2021-07-28-tokyo-olympics.mdx
@@ -1,7 +1,0 @@
----
-date: "2021-07-28"
-title: "Olympics"
-byline: "By Peter Zhang, Sanjana Melkote and Michelle Li"
-subhead: "Looking at UC Berkeley Athletics' Olympics History"
-featuredImage: "../images/gatsby-icon.png"
----


### PR DESCRIPTION
Reverts dailycal-projects/dailycalprojects#10

Hey all, 

I'm reverting this merge since it was pushed to master instead of your local olympics branch, and overrode previous work to the deployed site. I'm sure it was just a mistake, but to reiterate: 

In the interest of not overriding previous ppl’s work and publishing a draft article before its ready, **teams should not merge to master** until other editors/team members have checked your work for conflicts. This way, we don't accidentally cause a deploy failure. Since our GitHub commits are to a Netlify hosted site (which offers continuous deployment), we should make sure 
1) we are testing deploys on local branches first through preview links
2) whatever we eventually merge does not undo other people's work

You do not need to merge to master in order to pull work done to your local branch! 
For instance, if I am in the olympics branch: 
- `git pull` gets changes only done to olympics
- `git pull origin master` gets changes from master branch 
- ` git push --set-upstream origin olympics` initializes the upstream branch as the LOCAL olympics branch. from then on, `git push` will push to olympics. It is not necessary to go through master to save your changes. 



@michelleli142 @petezh 