### PR TITLE
Updated link to direct to correct article

### DIFF
--- a/src/articles/2015-12-11-lowest-grades.mdx
+++ b/src/articles/2015-12-11-lowest-grades.mdx
@@ -3,5 +3,5 @@ date: "2015-12-11"
 title: "Guess the UC Berkeley department with the lowest grades"
 byline: "By Sahil Chinoy and Ronald Kwan"
 featuredImage: "../images/lowest-grades.png"
-oldLink: "http://projects.dailycal.org/affirmative-action/"
+oldLink: "http://projects.dailycal.org/grades/"
 ---


### PR DESCRIPTION
Updated link in src/articles/2015-12-11-lowest-grades.mdx from http://projects.dailycal.org/affirmative-action/ to http://projects.dailycal.org/grades/ because it had been linking to the wrong article. @shannonbonet